### PR TITLE
Minigame Holder bug fixed

### DIFF
--- a/LovettePies/Assets/Prefabs/CustomerPrefabs/PoliceGroup.prefab
+++ b/LovettePies/Assets/Prefabs/CustomerPrefabs/PoliceGroup.prefab
@@ -44,6 +44,10 @@ PrefabInstance:
       value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1179349401, guid: cd55feb7f310114478090f155597f642, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1179349401, guid: cd55feb7f310114478090f155597f642, type: 3}
       propertyPath: m_EndActions.m_PersistentCalls.m_Calls.Array.size
       value: 3
       objectReference: {fileID: 0}
@@ -108,6 +112,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4128154384564195074, guid: cd55feb7f310114478090f155597f642, type: 3}
+      propertyPath: m_MovementFlag
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4128154384564195074, guid: cd55feb7f310114478090f155597f642, type: 3}
       propertyPath: m_MovementSpeed
       value: 0.08
       objectReference: {fileID: 0}
@@ -162,6 +170,10 @@ PrefabInstance:
     - target: {fileID: 4128154384564195087, guid: cd55feb7f310114478090f155597f642, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7605453843455599487, guid: cd55feb7f310114478090f155597f642, type: 3}
+      propertyPath: m_MovementFlag
+      value: 16
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd55feb7f310114478090f155597f642, type: 3}

--- a/LovettePies/Assets/Scripts/Barbershop/BarberSeat.cs
+++ b/LovettePies/Assets/Scripts/Barbershop/BarberSeat.cs
@@ -47,6 +47,7 @@ public class BarberSeat : MinigameHolderBase
                     }
 
                     m_SeatSocket.PeekObj().GetComponent<BarbershopBehavior>().HaircutBegins();
+                    m_CurrentActivated = true;
                     SceneManager.LoadSceneAsync(m_BarberMinigame, LoadSceneMode.Additive);
                 }
                 break;

--- a/LovettePies/Assets/Scripts/CustomerScripts/GeneralCustomerScript.cs
+++ b/LovettePies/Assets/Scripts/CustomerScripts/GeneralCustomerScript.cs
@@ -157,7 +157,7 @@ public class GeneralCustomerScript : MonoBehaviour
         m_InteractionDirection = GlobalNamespace.GeneralFunctions.GetDirection(m_CellPos.m_CurCellPos, new Vector2Int(PosAIdx.Item1.y, PosAIdx.Item1.x));
         m_CurrentInteractableSeat = CellElement.AreaArray[m_CellPos.AreaIdx].GetInteractable(PosAIdx.Item1);
         m_CurrentInteractableSeat.Interact(this, m_InteractionDirection);
-        m_PatienceTimer.Play();
+        m_PatienceTimer?.Play();
         m_TargetIdx++;
 
         m_PatienceActions?.Invoke();

--- a/LovettePies/Assets/Scripts/GeneralComponents/MinigameHolderBase.cs
+++ b/LovettePies/Assets/Scripts/GeneralComponents/MinigameHolderBase.cs
@@ -21,13 +21,15 @@ public abstract class MinigameHolderBase : Interactable
         SceneManager.sceneLoaded -= MinigameLoaded;
     }
 
+    protected bool m_CurrentActivated = false;
     protected virtual void MinigameLoaded(Scene p_MinigameScene, LoadSceneMode _p_LoadSceneMode)
     {
-        if (p_MinigameScene.name == "OneAreaNavigationTest")
+        if (!m_CurrentActivated || p_MinigameScene.name == "OneAreaNavigationTest")
         {
             return;
         }
 
+        m_CurrentActivated = false;
         //p_MinigameScene.GetRootGameObjects();
         Debug.LogWarning($"WARNING: {p_MinigameScene.name} LOADED AND TRIGGERED FUNCTION!");
         foreach (var MGHolder in GameObject.FindGameObjectsWithTag("MinigameHolder"))

--- a/LovettePies/Assets/Scripts/Player/DocumentMiniGameController.cs
+++ b/LovettePies/Assets/Scripts/Player/DocumentMiniGameController.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-public class DocumentMinigameController : MonoBehaviour
+public class DocumentMiniGameController : MonoBehaviour
 {
     private PlayerControls m_PlayerControls;
     private void Awake()

--- a/LovettePies/Assets/Scripts/PoliceStation/PoliceStationTable.cs
+++ b/LovettePies/Assets/Scripts/PoliceStation/PoliceStationTable.cs
@@ -42,6 +42,7 @@ public class PoliceStationTable : MinigameHolderBase
         {
             case "Player":
                 {
+                    m_CurrentActivated = true;
                     SceneManager.LoadSceneAsync(m_PoliceTableMinigame, LoadSceneMode.Additive);
                 }
                 break;

--- a/LovettePies/Assets/Scripts/Restaurant/DishWasher.cs
+++ b/LovettePies/Assets/Scripts/Restaurant/DishWasher.cs
@@ -36,6 +36,7 @@ public class DishWasher : MinigameHolderBase
         }
 
         m_LocalSocket.Stack(m_OriginSocket.RemoveObj());
+        m_CurrentActivated = true;
         SceneManager.LoadSceneAsync(m_DishWasherMinigame, LoadSceneMode.Additive);
         m_IsInteractable[0] = false;
     }

--- a/LovettePies/Assets/Scripts/Restaurant/SingleIngredientCook.cs
+++ b/LovettePies/Assets/Scripts/Restaurant/SingleIngredientCook.cs
@@ -49,6 +49,7 @@ public class SingleIngredientCook : MinigameHolderBase
             m_CookingName = Ingred.m_IngredientDescription.m_MinigameName;
             m_OriginalSocket = PlayerPlate.m_IngredientSockets[m_IngredIdx];
             m_LocalSocket.Stack(m_OriginalSocket.RemoveObj());
+            m_CurrentActivated = true;
             SceneManager.LoadSceneAsync(m_CookingName, LoadSceneMode.Additive);
             Debug.LogWarning("WARNING: LOCKING MINIGAME HOLDER!");
             m_IsInteractable[0] = false;

--- a/LovettePies/Assets/_Scenes/PoliceStationLevel.unity
+++ b/LovettePies/Assets/_Scenes/PoliceStationLevel.unity
@@ -2104,7 +2104,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6519495896957005194, guid: 4a9f30f6e7d4c44419765cb393b34714, type: 3}
       propertyPath: m_PatienceActions.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: LeaveArea
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 6519495896957005194, guid: 4a9f30f6e7d4c44419765cb393b34714, type: 3}
       propertyPath: m_PatienceActions.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
@@ -2161,6 +2161,10 @@ PrefabInstance:
     - target: {fileID: 9177146435033267329, guid: 4a9f30f6e7d4c44419765cb393b34714, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9177146435033267341, guid: 4a9f30f6e7d4c44419765cb393b34714, type: 3}
+      propertyPath: m_MovementFlag
+      value: 18
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4a9f30f6e7d4c44419765cb393b34714, type: 3}


### PR DESCRIPTION
Police Group Pathfinding was broken due to the several Minigame Holder objects reacting to the Minigame Loading, even if the Minigame Holder Interactee object was not the one activated, which screwed with the PoliceGroup prefab to "release" criminals when the criminal was already let go, breaking the Pathfinding.